### PR TITLE
Add reuse session

### DIFF
--- a/bricklink_api/method.py
+++ b/bricklink_api/method.py
@@ -9,6 +9,8 @@ from . import url as _url
 import requests
 
 
+s = requests.Session()
+
 class Method(_enum.Enum):
   GET = "GET"
   POST = "POST"
@@ -40,6 +42,5 @@ def method(
     **kwargs
 ) -> Any:
   preq = request(request_method, uri, **kwargs)
-  with requests.Session() as s:
-    resp = s.send(preq)
+  resp = s.send(preq)
   return resp.json()


### PR DESCRIPTION
Instead of creating a new session for every request, my proposed change introduces a global session which is reused for all requests.
This results in a significant performance improvement due to the reuse of the underlying TCP connection, which prevents time-consuming handshakes. The performance improvement is also described in the corresponding [requests documentation](https://requests.readthedocs.io/en/latest/user/advanced/#session-objects).

Remark: Because by this change no Context Manager(e.g. `with`) is used any more it may happen that the session isn't properly managed and released. If someone knows how to fix this elegantly feel free to edit the pull request.